### PR TITLE
Fixed ClearSallyPort and CalibrateArm

### DIFF
--- a/CompetitionRobot/src/org/frc4931/robot/SallyPortCommands/ClearSallyPort.java
+++ b/CompetitionRobot/src/org/frc4931/robot/SallyPortCommands/ClearSallyPort.java
@@ -1,8 +1,8 @@
 package org.frc4931.robot.SallyPortCommands;
 
+import org.frc4931.robot.TimedDriveCommand;
 import org.frc4931.robot.arm.Arm;
 import org.frc4931.robot.arm.MoveArmTo;
-import org.frc4931.robot.drive.Drive;
 import org.frc4931.robot.drive.DriveSystem;
 
 public class ClearSallyPort extends org.strongback.command.CommandGroup
@@ -13,6 +13,6 @@ public class ClearSallyPort extends org.strongback.command.CommandGroup
 	public ClearSallyPort(DriveSystem d,Arm a)
 	{
 		//TODO fine tune this
-		sequentially(new MoveArmTo(ANGLE,a),new Drive(d, DRIVE_SPEED, 0, DRIVE_TIME));
+		sequentially(new MoveArmTo(ANGLE,a), new TimedDriveCommand(d, DRIVE_SPEED, 0, DRIVE_TIME));
 	}
 }

--- a/CompetitionRobot/src/org/frc4931/robot/arm/CalibrateArm.java
+++ b/CompetitionRobot/src/org/frc4931/robot/arm/CalibrateArm.java
@@ -43,6 +43,7 @@ public class CalibrateArm extends Command {
     @Override
     public void end() {
         arm.stop();
+        pause(1.0);
         arm.zero();
     }
 }


### PR DESCRIPTION
Fixes a compile error caused by `ClearSallyPort` and adds a delay in `CalibrateArm` to allow the motor to fully stop before zeroing.
